### PR TITLE
Honor common compiler and linker flags

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+- Honor common compiler and linker flags
+
 Version 0.4.6:
 - Added Feature for not creating a header e.g. for already existing HTML-files (thanks to Nicolas Zagulajew)
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 all: aha
 
 aha: aha.c
-	gcc -std=c99 aha.c -o aha
+	gcc -std=c99 $(CFLAGS) $(LDFLAGS) $(CPPFLAGS) aha.c -o aha


### PR DESCRIPTION
This would help distributions which prefer specific compiler and linker flags (like the hardening flags in Debian) to get them working without patching and shouldn't do any harm if these variables are not set at all.
