### PR TITLE
Fix a few warnings raised by cppcheck

### DIFF
--- a/aha.c
+++ b/aha.c
@@ -39,21 +39,6 @@ int getNextChar(register FILE* fp)
 	exit(1);
 }
 
-int getFutureChar(register FILE* fp)
-{
-	int c;
-	if (future)
-		return future_char;
-	if ((c = fgetc(fp)) != EOF)
-	{
-		future=1;
-		future_char=c;
-		return c;
-	}
-	fprintf(stderr,"Unknown Error in File Parsing!\n");
-	exit(1);
-}
-
 typedef struct selem *pelem;
 typedef struct selem {
 	unsigned char digit[8];


### PR DESCRIPTION
$ cppcheck aha.c  --enable=all
Checking aha.c...
[aha.c:619]: (style) Consecutive return, break, continue, goto or throw statements are unnecessary
[aha.c:77]: (style) Checking if unsigned variable 'digitcount' is less than zero.
Checking usage of global functions..
[aha.c:42]: (style) The function 'getFutureChar' is never used
