### PR TITLE
Clean target must not fail if there's nothing to clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ aha: aha.c
 	gcc -std=c99 $(CFLAGS) $(LDFLAGS) $(CPPFLAGS) aha.c -o aha
 
 clean:
-	rm aha
+	rm -f aha
 
 install: aha
 	install -d $(BIN)


### PR DESCRIPTION
The Debian package no more builts properly, because it runs "make clean" always before building, even if no build happened before:

```
 dpkg-source -i --before-build aha
dpkg-buildpackage: host architecture amd64
 fakeroot debian/rules clean
dh clean
   dh_testdir
   dh_auto_clean
make[1]: Entering directory '/home/abe/aha/aha'
rm aha
rm: cannot remove ‘aha’: No such file or directory
Makefile:16: recipe for target 'clean' failed
make[1]: *** [clean] Error 1
make[1]: Leaving directory '/home/abe/aha/aha'
dh_auto_clean: make -j1 clean returned exit code 2
debian/rules:8: recipe for target 'clean' failed
make: *** [clean] Error 2
dpkg-buildpackage: error: fakeroot debian/rules clean gave error exit status 2
```

This patch fixes the issue.
