### PR TITLE
Fix some clang compiler warnings on OS X

### DIFF
--- a/aha.c
+++ b/aha.c
@@ -613,20 +613,26 @@ int main(int argc,char* args[])
 										 break; //Reset
 					}
 					if (ul)
+          {
 						if (stylesheet)
 							printf("underline ");
 						else
 							printf("text-decoration:underline;");
+          }
 					if (bo)
+          {
 						if (stylesheet)
 							printf("bold ");
 						else
 							printf("font-weight:bold;");
+          }
 					if (bl)
+          {
 						if (stylesheet)
 							printf("blink ");
 						else
 							printf("text-decoration:blink;");
+          }
 
 					printf("\">");
 				}


### PR DESCRIPTION
Apple LLVM version 6.0 (clang-600.0.54) (based on LLVM 3.5svn)
Target: x86_64-apple-darwin14.0.0
