### PR TITLE
POSIX-ify Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 .PHONY: all clean install
 
-ifndef PREFIX
-    PREFIX=/usr/local
-endif
+PREFIX?=/usr/local
 
 BIN:=$(DESTDIR)$(PREFIX)/bin
 MAN:=$(DESTDIR)$(PREFIX)/man/man1


### PR DESCRIPTION
Replace GNU make syntax with POSIX standard equivalent. This allows the
software to be built with other versions of 'make' (e.g., on BSD).