### PR TITLE
Fix description of the --title option in the manual page

### DIFF
--- a/aha.1
+++ b/aha.1
@@ -32,7 +32,7 @@ Use a stylesheet instead of inline styles
 Uses ISO 8859-X instead of utf-8. X must be 1..16
 .TP
 \fB\-\-title X , \-t X
-Gives the html output the title \"X\" instead of stdin or the filename
+Gives the html output the title "X" instead of stdin or the filename
 .TP
 \fB\-\-line\-fix , \-l
 Uses a fix for inputs using control sequences to change the cursor position like htop. It's a hot fix, it may not work with any program like htop. (See \fBEXAMPLE\fP)


### PR DESCRIPTION
In the roff language, the escaped double quote (`\"`) introduces a comment;
use plain double quote (`"`) instead.