### PR TITLE
fix MANDIR variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 PREFIX?=/usr/local
 
-MANDIR?=$(PREFIX)/share/man
+MANDIR?=$(PREFIX)/man
 BINMODE?=0755
 MANMODE?=644
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 PREFIX?=/usr/local
 
-MANDIR?=man
+MANDIR?=$(PREFIX)/share/man
 BINMODE?=0755
 MANMODE?=644
 
@@ -17,5 +17,5 @@ clean:
 install: aha
 	install -d $(DESTDIR)$(PREFIX)/bin
 	install -m $(BINMODE) aha $(DESTDIR)$(PREFIX)/bin
-	install -d $(DESTDIR)$(PREFIX)/$(MANDIR)/man1
-	install -m $(MANMODE) aha.1 $(DESTDIR)$(PREFIX)/$(MANDIR)/man1
+	install -d $(DESTDIR)$(MANDIR)/man1
+	install -m $(MANMODE) aha.1 $(DESTDIR)$(MANDIR)/man1


### PR DESCRIPTION
Using `MANDIR` as it is described by the [GNU Coding Standards], to increase interoperability with package managers and operating systems. Previously, `MANDIR` was a variable that described a path relative to `PREFIX`; however, it should be an **absolute** path.

Related discussions:
 * https://github.com/Homebrew/homebrew-core/pull/11208
 * https://github.com/theZiz/aha/pull/15

[GNU Coding Standards]: https://www.gnu.org/prep/standards/html_node/Directory-Variables.html