### PR TITLE
Use datarootdir in compliance with GNU coding standards.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@
 
 PREFIX?=/usr/local
 
-MANDIR?=$(PREFIX)/man
+DATAROOTDIR?=$(PREFIX)/share
+MANDIR?=$(DATAROOTDIR)/man
+
 BINMODE?=0755
 MANMODE?=644
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ Compilation / Installation
 Aha has no dependencies except for a C compiler and `make`.
 
 To compile just type `make`.
-To install aha type `make install`.
+To install aha to `/usr/local/` type `make install`.
 You can change the installation directory with `make install PREFIX=/your/path`.
+You can override the man directory with `make install MANDIR=/your/path/man`
 
 Licensing
 =========


### PR DESCRIPTION
Following our discussion from #27: `MANDIR` is now defined in terms of `DATAROOTDIR` as specified by the [GNU Coding Standards](https://www.gnu.org/prep/standards/html_node/Directory-Variables.html). This also means that `MANDIR` now points to `/usr/local/share/man`, breaking compatibility with previous versions of aha.

Let me know what you think!