### PR TITLE
Print IO error names

### DIFF
--- a/aha.c
+++ b/aha.c
@@ -20,6 +20,7 @@
 #define AHA_VERSION "0.4.10.6"
 #define TEST
 #define AHA_YEAR "2017"
+#include <errno.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -269,7 +270,8 @@ int main(int argc,char* args[])
 			fp = fopen(args[p+1],"r");
 			if (fp==NULL)
 			{
-				fprintf(stderr,"file \"%s\" not found!\n",args[p+1]);
+				char *errstr = strerror(errno);
+				fprintf(stderr,"Failed to open file \"%s\": %s\n",args[p+1],errstr);
 				exit(EXIT_FAILURE);
 			}
 			p++;

--- a/aha.c
+++ b/aha.c
@@ -73,7 +73,8 @@ int getNextChar(register FILE* fp)
 	int c;
 	if ((c = fgetc(fp)) != EOF)
 		return c;
-	fprintf(stderr,"Unknown Error in File Parsing!\n");
+		
+	perror("Error while parsing input");
 	exit(EXIT_FAILURE);
 }
 


### PR DESCRIPTION
This changeset makes the program print error names when failing to open a file that was provided using the `-p` option, or when reading the next byte in `getNextChar()` fails.