### PR TITLE
Enable warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ MANDIR?=$(DATAROOTDIR)/man
 BINMODE?=0755
 MANMODE?=644
 
+CFLAGS += -Wall -Wextra
+
 all: aha
 
 aha: aha.c

--- a/aha.c
+++ b/aha.c
@@ -764,7 +764,6 @@ int main(int argc,char* args[])
 				}
 				newline=-1;
 			}
-			char temp_buffer[2];
 			switch (c)
 			{
 				case '&':	printf("&amp;"); break;

--- a/aha.c
+++ b/aha.c
@@ -386,7 +386,7 @@ int main(int argc,char* args[])
 	}
 
 	//Begin of Conversion
-	unsigned int c;
+	int c;
 	int fc = -1; //Standard Foreground Color //IRC-Color+8
 	int bc = -1; //Standard Background Color //IRC-Color+8
 	int ul = 0; //Not underlined


### PR DESCRIPTION
This changeset adds warnings to `CFLAGS` and fixes two places which emitted warnings: unsigned-vs-signed-int comparison and an unused variable.