### PR TITLE
Put application state into struct

### DIFF
--- a/aha.c
+++ b/aha.c
@@ -456,8 +456,7 @@ int main(int argc,char* args[])
 								mompos++;
 							if (mompos==momelem->digitcount) //only zeros => delete all
 							{
-								state.fc = state.bc = -1;
-								state.bold = state.underline = state.blink = 0;
+								state = default_state;
 								negative=0;special_char=0;
 							}
 							else


### PR DESCRIPTION
This changeset puts the output state (colours, bold, underline, blink) into a struct. This allows to remove state change checks with calls to a new function, `statesDiffer`, making "forgot to change code in one place" errors less likely.