### PR TITLE
Fix italics CSS (is "font-weight", should be "font-style")

### DIFF
--- a/aha.c
+++ b/aha.c
@@ -709,7 +709,7 @@ int main(int argc,char* args[])
 							if (opts.stylesheet)
 								printf("italic ");
 							else
-								printf("font-weight:italic;");
+								printf("font-style:italic;");
 						}
 						if (state.blink)
 						{


### PR DESCRIPTION
This PR fixes a bug where the wrong CSS property was used for making the text _italic_.