### PR TITLE
Remove extra linebreak at end

### DIFF
--- a/aha.c
+++ b/aha.c
@@ -1059,7 +1059,7 @@ int main(int argc,char* args[])
 
 	// If current state is different than the default, there is a <span> open - close it
 	if (statesDiffer(&state, &default_state))
-		printf("</span>\n");
+		printf("</span>");
 
 	//Footer
 	if (opts.no_header == 0)


### PR DESCRIPTION
Hey, aha is pretty cool! I'm using it in conjuction with wkhtmltoimage to capture clean ‘screenshots’ of terminal output.

One issue I've noticed is that the images thus produced often have an extra blank line at the end, which I think is due to this `\n` inserted with the span close tag when there's some ANSI formatting still in effect at the last character—this PR takes it out.