### PR TITLE
Preserve timestamps in "make install"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,5 @@ clean:
 	rm -f aha
 
 install: aha
-	$(INSTALL) -d $(DESTDIR)$(PREFIX)/bin
-	$(INSTALL) -m $(BINMODE) aha $(DESTDIR)$(PREFIX)/bin
-	$(INSTALL) -d $(DESTDIR)$(MANDIR)/man1
-	$(INSTALL) -m $(MANMODE) aha.1 $(DESTDIR)$(MANDIR)/man1
+	$(INSTALL) -D -m $(BINMODE) aha $(DESTDIR)$(PREFIX)/bin/aha
+	$(INSTALL) -D -m $(MANMODE) aha.1 $(DESTDIR)$(MANDIR)/man1/aha.1

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: all clean install
 
 PREFIX?=/usr/local
-
 DATAROOTDIR?=$(PREFIX)/share
 MANDIR?=$(DATAROOTDIR)/man
 
+INSTALL?=install -p
 BINMODE?=0755
 MANMODE?=644
 
@@ -19,7 +19,7 @@ clean:
 	rm -f aha
 
 install: aha
-	install -d $(DESTDIR)$(PREFIX)/bin
-	install -m $(BINMODE) aha $(DESTDIR)$(PREFIX)/bin
-	install -d $(DESTDIR)$(MANDIR)/man1
-	install -m $(MANMODE) aha.1 $(DESTDIR)$(MANDIR)/man1
+	$(INSTALL) -d $(DESTDIR)$(PREFIX)/bin
+	$(INSTALL) -m $(BINMODE) aha $(DESTDIR)$(PREFIX)/bin
+	$(INSTALL) -d $(DESTDIR)$(MANDIR)/man1
+	$(INSTALL) -m $(MANMODE) aha.1 $(DESTDIR)$(MANDIR)/man1


### PR DESCRIPTION
This changeset makes the Makefile use the `INSTALL` variable during "make install".
The default value is set to `install -p` so that file timestamps are preserved.