### PR TITLE
Escape HTML where needed

### DIFF
--- a/aha.c
+++ b/aha.c
@@ -541,7 +541,11 @@ void printHeader(const struct Options *opts)
 	printf("</title>\n");
 
 	if (opts->css)
-		printf("<link rel=\"stylesheet\" href=\"%s\" />\n", opts->css );
+	{
+		printf("<link rel=\"stylesheet\" href=\"");
+		printHtml(opts->css);
+		printf("\">\n");
+	}
 
 	int style_tag = 0;
 	if (opts->stylesheet)

--- a/aha.c
+++ b/aha.c
@@ -637,7 +637,7 @@ void printHeader(const struct Options *opts)
 		    }
 		    if(opts->bodystyle) {
 			if(styles) printf(";");
-			fputs(opts->bodystyle, stdout);
+			printHtml(opts->bodystyle);
 		    }
 		    printf("\"");
 		}

--- a/aha.c
+++ b/aha.c
@@ -511,17 +511,29 @@ void printHeader(const struct Options *opts)
 	if (opts->no_xml)
 	{
 		if (opts->lang)
-			printf("<html lang=\"%s\">\n",opts->lang);
+		{
+			printf("<html lang=\"");
+			printHtml(opts->lang);
+			printf("\">\n");
+		}
 		else
+		{
 			printf("<html>\n");
+		}
 		printf("<head>\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=%s\">\n", encoding);
 	}
 	else
 	{
 		if (opts->lang)
-			printf("<html xmlns=\"http://www.w3.org/1999/xhtml\" lang=\"%s\">\n",opts->lang);
+		{
+			printf("<html xmlns=\"http://www.w3.org/1999/xhtml\" lang=\"");
+			printHtml(opts->lang);
+			printf("\">\n");
+		}
 		else
+		{
 			printf("<html xmlns=\"http://www.w3.org/1999/xhtml\">\n");
+		}
 		printf("<head>\n<meta http-equiv=\"Content-Type\" content=\"application/xml+xhtml; charset=%s\"/>\n", encoding);
 	}
 	printf("<title>");


### PR DESCRIPTION
Some of the program options take arguments that are then printed inside the document, such as `--title` or `--style`. Some of those were printed as-is, without properly escaping HTML entities. This changeset replaces "raw" prints with safe ones.