### PR TITLE
Color improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,11 @@ all: aha
 
 aha: aha.c
 	$(CC) $(CFLAGS) $(LDFLAGS) $(CPPFLAGS) aha.c -o $@
+test_print: test_print.c
+	$(CC) $(CFLAGS) $(LDFLAGS) $(CPPFLAGS) test_print.c -o $@
 
 clean:
-	rm -f aha
+	rm -f aha aha_test
 
 install: aha
 ifeq ($(platform), Darwin)

--- a/aha.1
+++ b/aha.1
@@ -21,6 +21,10 @@ The options are as follows:
 .Bl -tag -width Ds
 .It Fl b , Fl Fl black
 Style HTML output to use a black background with white text.
+.It Fl Fl colors
+Style HTML output to use a black background with white text.
+Set a custom color scheme. X must be a comma-separated list of 18 CSS colors representing the default colors and all 16 4-bit color codes:
+"foreground, background, black, red, green, yellow, blue, magenta, cyan, white, (+ bright versions of those eight)"
 .It Fl c Ar file , Fl Fl css Ar file
 Adds the given css
 .Ar file
@@ -95,6 +99,12 @@ Create an HTML file with a white background using the output of
 .Xr diff 1 :
 .Pp
 .Dl $ diff -u --color=always oldfile.c newfile.c | aha > diff.html
+.Pp
+Create an HTML file with a white foreground, blue background, and mapping every 4-bit color code to red using
+.Nm Ap s
+help:
+.Pp
+.Dl $ aha -h | aha --colors '#fff,#00f,red,red,red,red,red,red,red,red,red,red,red,red,red,red,red,red' > aha-help.html
 .Pp
 Create an HTML file with a black background from the output of
 .Xr htop 1 .

--- a/aha.c
+++ b/aha.c
@@ -436,7 +436,7 @@ struct Options parseArgs(int argc, char* args[])
 }
 
 enum ColorMode {
-	MODE_3BIT,
+	MODE_4BIT,
 	MODE_8BIT,
 	MODE_24BIT
 };
@@ -450,17 +450,14 @@ struct State {
 	int crossedout;
 	enum ColorMode fc_colormode;
 	enum ColorMode bc_colormode;
-	int highlighted; //for fc AND bc although not correct...
-	int fc_highlighted;
-	int bc_highlighted;
 };
 
 void swapColors(struct State *const state) {
-	if (state->bc_colormode == MODE_3BIT && state->bc == -1)
-		state->bc = 8;
+	if (state->bc_colormode == MODE_4BIT && state->bc == -1)
+		state->bc = 16;
 
-	if (state->fc_colormode == MODE_3BIT && state->fc == -1)
-		state->fc = 9;
+	if (state->fc_colormode == MODE_4BIT && state->fc == -1)
+		state->fc = 17;
 
 	int temp = state->bc;
 	state->bc = state->fc;
@@ -480,11 +477,8 @@ const struct State default_state = {
 	.underline = 0,
 	.blink = 0,
 	.crossedout = 0,
-	.fc_colormode = MODE_3BIT,
-	.bc_colormode = MODE_3BIT,
-	.highlighted = 0,
-	.fc_highlighted = 0,
-	.bc_highlighted = 0,
+	.fc_colormode = MODE_4BIT,
+	.bc_colormode = MODE_4BIT,
 };
 
 int statesDiffer(const struct State *const old, const struct State *const new) {
@@ -497,17 +491,13 @@ int statesDiffer(const struct State *const old, const struct State *const new) {
 		(old->blink != new->blink) ||
 		(old->crossedout != new->crossedout) ||
 		(old->fc_colormode != new->fc_colormode) ||
-		(old->bc_colormode != new->bc_colormode) ||
-		(old->highlighted != new->highlighted) ||
-		(old->fc_highlighted != new->fc_highlighted) ||
-		(old->bc_highlighted != new->bc_highlighted);
+		(old->bc_colormode != new->bc_colormode);
 }
 
 struct ColorStyle {
 	char* fg_default;
 	char* bg_default;
-	char* colors[10];
-	char* bright_colors[10];
+	char* colors[18];
 };
 
 const struct ColorStyle styles[3] = {
@@ -523,10 +513,6 @@ const struct ColorStyle styles[3] = {
 			"purple", // Magenta
 			"teal", // Cyan
 			"gray", // White
-			"white", // Default Background
-			"black"  // Default Foreground
-		},
-		.bright_colors = {
 			"dimgray", // Bright Black
 			"red", // Bright Red
 			"green", // Bright Green
@@ -552,10 +538,6 @@ const struct ColorStyle styles[3] = {
 			"fuchsia", // Magenta
 			"aqua", // Cyan
 			"white", // White
-			"black", // Default Background
-			"white"  // Default Foreground
-		},
-		.bright_colors = {
 			"black", // Bright Black
 			"red", // Bright Red
 			"lime", // Bright Green
@@ -581,10 +563,6 @@ const struct ColorStyle styles[3] = {
 			"purple", // Magenta
 			"teal", // Cyan
 			"gray", // White
-			"pink", // Default Background
-			"black"  // Default Foreground
-		},
-		.bright_colors = {
 			"dimgray", // Bright Black
 			"red", // Bright Red
 			"green", // Bright Green
@@ -663,29 +641,46 @@ void printHeader(const struct Options *opts)
 		printf(".inverted    {color: %s;}\n", style.bg_default);
 		printf(".bg-inverted {background-color: %s;}\n", style.fg_default);
 
-		printf(".dimgray     {color: %s;}\n", style.colors[0]);
-		printf(".red         {color: %s;}\n", style.colors[1]);
-		printf(".green       {color: %s;}\n", style.colors[2]);
-		printf(".yellow      {color: %s;}\n", style.colors[3]);
-		printf(".blue        {color: %s;}\n", style.colors[4]);
-		printf(".purple      {color: %s;}\n", style.colors[5]);
-		printf(".cyan        {color: %s;}\n", style.colors[6]);
-		printf(".white       {color: %s;}\n", style.colors[7]);
-		printf(".bg-black    {background-color: %s;}\n", style.colors[0]);
-		printf(".bg-red      {background-color: %s;}\n", style.colors[1]);
-		printf(".bg-green    {background-color: %s;}\n", style.colors[2]);
-		printf(".bg-yellow   {background-color: %s;}\n", style.colors[3]);
-		printf(".bg-blue     {background-color: %s;}\n", style.colors[4]);
-		printf(".bg-purple   {background-color: %s;}\n", style.colors[5]);
-		printf(".bg-cyan     {background-color: %s;}\n", style.colors[6]);
-		printf(".bg-white    {background-color: %s;}\n", style.colors[7]);
+		printf(".dimgray {color: %s;}\n", style.colors[0]);
+		printf(".red     {color: %s;}\n", style.colors[1]);
+		printf(".green   {color: %s;}\n", style.colors[2]);
+		printf(".yellow  {color: %s;}\n", style.colors[3]);
+		printf(".blue    {color: %s;}\n", style.colors[4]);
+		printf(".purple  {color: %s;}\n", style.colors[5]);
+		printf(".cyan    {color: %s;}\n", style.colors[6]);
+		printf(".white   {color: %s;}\n", style.colors[7]);
+		printf(".dimgray.highlighted {color: %s;}\n", style.colors[8]);
+		printf(".red    .highlighted {color: %s;}\n", style.colors[9]);
+		printf(".green  .highlighted {color: %s;}\n", style.colors[10]);
+		printf(".yellow .highlighted {color: %s;}\n", style.colors[11]);
+		printf(".blue   .highlighted {color: %s;}\n", style.colors[12]);
+		printf(".purple .highlighted {color: %s;}\n", style.colors[13]);
+		printf(".cyan   .highlighted {color: %s;}\n", style.colors[14]);
+		printf(".white  .highlighted {color: %s;}\n", style.colors[15]);
+
+		printf(".bg-black  {background-color: %s;}\n", style.colors[0]);
+		printf(".bg-red    {background-color: %s;}\n", style.colors[1]);
+		printf(".bg-green  {background-color: %s;}\n", style.colors[2]);
+		printf(".bg-yellow {background-color: %s;}\n", style.colors[3]);
+		printf(".bg-blue   {background-color: %s;}\n", style.colors[4]);
+		printf(".bg-purple {background-color: %s;}\n", style.colors[5]);
+		printf(".bg-cyan   {background-color: %s;}\n", style.colors[6]);
+		printf(".bg-white  {background-color: %s;}\n", style.colors[7]);
+		printf(".bg-black .bg-highlighted {color: %s;}\n", style.colors[8]);
+		printf(".bg-red   .bg-highlighted {color: %s;}\n", style.colors[9]);
+		printf(".bg-green .bg-highlighted {color: %s;}\n", style.colors[10]);
+		printf(".bg-yellow.bg-highlighted {color: %s;}\n", style.colors[11]);
+		printf(".bg-blue  .bg-highlighted {color: %s;}\n", style.colors[12]);
+		printf(".bg-purple.bg-highlighted {color: %s;}\n", style.colors[13]);
+		printf(".bg-cyan  .bg-highlighted {color: %s;}\n", style.colors[14]);
+		printf(".bg-white .bg-highlighted {color: %s;}\n", style.colors[15]);
+
 
 		printf(".underline   {text-decoration: underline;}\n");
 		printf(".bold        {font-weight: bold;}\n");
 		printf(".italic      {font-style: italic;}\n");
 		printf(".blink       {text-decoration: blink;}\n");
 		printf(".crossed-out {text-decoration: line-through;}\n");
-		printf(".highlighted {filter: contrast(70%%) brightness(190%%);}\n");
 	}
 
 	if (opts->word_wrap)
@@ -728,7 +723,7 @@ int main(int argc,char* args[])
 
 	struct ColorStyle style = styles[opts.colorscheme];
 
-	char* fcclass[10] = {
+	char* fcclass[18] = {
 		"dimgray", // Black
 		"red", // Red
 		"green", // Green
@@ -737,11 +732,19 @@ int main(int argc,char* args[])
 		"purple", // Magenta
 		"cyan", // Cyan
 		"white", // White
+		"highlighted dimgray", // Bright Black
+		"highlighted red", // Bright Red
+		"highlighted green", // Bright Green
+		"highlighted yellow", // Bright Yellow
+		"highlighted blue", // Bright Blue
+		"highlighted purple", // Bright Magenta
+		"highlighted cyan", // Bright Cyan
+		"highlighted white", // Bright White
 		"inverted", // Default Background
 		"reset" // Default Foreground
 	};
 
-	char* bcclass[10] = {
+	char* bcclass[18] = {
 		"bg-black", // Black
 		"bg-red", // Red
 		"bg-green", // Green
@@ -750,6 +753,14 @@ int main(int argc,char* args[])
 		"bg-purple", // Magenta
 		"bg-cyan", // Cyan
 		"bg-white", // White
+		"bg-highlighted bg-black", // Bright Black
+		"bg-highlighted bg-red", // Bright Red
+		"bg-highlighted bg-green", // Bright Green
+		"bg-highlighted bg-yellow", // Bright Yellow
+		"bg-highlighted bg-blue", // Bright Blue
+		"bg-highlighted bg-purple", // Bright Magenta
+		"bg-highlighted bg-cyan", // Bright Cyan
+		"bg-highlighted bg-white", // Bright White
 		"bg-reset", // Default Background
 		"bg-inverted" // Default Foreground
 	};
@@ -878,16 +889,7 @@ int main(int argc,char* args[])
 										{
 											momelem = momelem->next->next;
 											state.fc_colormode = MODE_8BIT;
-											if (momelem->value >=8 && momelem->value <=15)
-											{
-												state.fc_highlighted = 1;
-												*dest = momelem->value-8;
-											}
-											else
-											{
-												state.fc_highlighted = 0;
-												*dest = momelem->value;
-											}
+											*dest = momelem->value;
 										}
 										else
 										if (momelem->value == 38 &&
@@ -905,7 +907,6 @@ int main(int argc,char* args[])
 											b = momelem;
 											if ( r && g && b )
 											{
-												state.fc_highlighted = 0;
 												state.fc_colormode = MODE_24BIT;
 												*dest =
 													(r->value & 255) * 65536 +
@@ -915,15 +916,13 @@ int main(int argc,char* args[])
 										}
 										else
 										{
-											state.fc_colormode = MODE_3BIT;
-											state.fc_highlighted = 0;
+											state.fc_colormode = MODE_4BIT;
 											*dest=momelem->value-30;
 										}
 									}
 									break;
 								case 39: // Set foreground color to default
-									state.fc_colormode = MODE_3BIT;
-									state.fc_highlighted = 0;
+									state.fc_colormode = MODE_4BIT;
 									state.fc = -1;
 									break;
 								case 40:
@@ -946,16 +945,7 @@ int main(int argc,char* args[])
 										{
 											momelem = momelem->next->next;
 											state.bc_colormode = MODE_8BIT;
-											if (momelem->value >=8 && momelem->value <=15)
-											{
-												state.bc_highlighted = 1;
-												*dest = momelem->value-8;
-											}
-											else
-											{
-												state.bc_highlighted = 0;
-												*dest = momelem->value;
-											}
+											*dest = momelem->value;
 										}
 										else
 										if (momelem->value == 48 &&
@@ -974,7 +964,6 @@ int main(int argc,char* args[])
 											if ( r && g && b )
 											{
 												state.bc_colormode = MODE_24BIT;
-												state.bc_highlighted = 0;
 												*dest =
 													(r->value & 255) * 65536 +
 													(g->value & 255) * 256 +
@@ -983,15 +972,13 @@ int main(int argc,char* args[])
 										}
 										else
 										{
-											state.bc_colormode = MODE_3BIT;
-											state.bc_highlighted = 0;
+											state.bc_colormode = MODE_4BIT;
 											*dest=momelem->value-40;
 										}
 									}
 									break;
 								case 49: // Set background color to default
-									state.bc_colormode = MODE_3BIT;
-									state.bc_highlighted = 0;
+									state.bc_colormode = MODE_4BIT;
 									state.bc = -1;
 									break;
 								case 90:
@@ -1006,9 +993,8 @@ int main(int argc,char* args[])
 										int *dest = &(state.fc);
 										if (negative != 0)
 											dest=&(state.bc);
-										state.fc_colormode = MODE_3BIT;
-										state.fc_highlighted = 1;
-										*dest=momelem->value-90;
+										state.fc_colormode = MODE_4BIT;
+										*dest=momelem->value-90+8;
 									}
 									break;
 
@@ -1024,9 +1010,8 @@ int main(int argc,char* args[])
 										int *dest = &(state.bc);
 										if (negative != 0)
 											dest=&(state.fc);
-										state.bc_colormode = MODE_3BIT;
-										state.bc_highlighted = 1;
-										*dest=momelem->value-100;
+										state.bc_colormode = MODE_4BIT;
+										*dest=momelem->value-100+8;
 									}
 									break;
 							}
@@ -1080,19 +1065,17 @@ int main(int argc,char* args[])
 								printf("blink ");
 							if(state.crossedout)
 								printf("crossed-out ");
-							if(state.fc_highlighted || state.bc_highlighted)
-								printf("highlighted ");
 
 							int needs_style = 0;
 							// classes first
 							switch (state.fc_colormode)
 							{
-								case MODE_3BIT:
-									if (state.fc>=0 && state.fc<=9)
+								case MODE_4BIT:
+									if (state.fc>=0 && state.fc<=17)
 										printf("%s ", fcclass[state.fc]);
 									break;
 								case MODE_8BIT:
-									if (state.fc>=0 && state.fc<=7)
+									if (state.fc>=0 && state.fc<=15)
 										printf("%s ", fcclass[state.fc]);
 									else
 										needs_style = 1;
@@ -1104,12 +1087,12 @@ int main(int argc,char* args[])
 
 							switch (state.bc_colormode)
 							{
-								case MODE_3BIT:
-									if (state.bc>=0 && state.bc<=9)
+								case MODE_4BIT:
+									if (state.bc>=0 && state.bc<=17)
 										printf("%s ", bcclass[state.bc]);
 									break;
 								case MODE_8BIT:
-									if (state.bc>=0 && state.bc<=7)
+									if (state.bc>=0 && state.bc<=15)
 										printf("%s ", bcclass[state.bc]);
 									else
 										needs_style = 1;
@@ -1126,10 +1109,10 @@ int main(int argc,char* args[])
 
 								switch (state.fc_colormode)
 								{
-									case MODE_3BIT:
+									case MODE_4BIT:
 										break;
 									case MODE_8BIT:
-										if (state.fc>=0 && state.fc<=7)
+										if (state.fc>=0 && state.fc<=15)
 											break;
 										char rgb[12];
 										make_rgb(state.fc,rgb);
@@ -1141,10 +1124,10 @@ int main(int argc,char* args[])
 								}
 								switch (state.bc_colormode)
 								{
-									case MODE_3BIT:
+									case MODE_4BIT:
 										break;
 									case MODE_8BIT:
-										if (state.bc>=0 && state.bc<=7)
+										if (state.bc>=0 && state.bc<=15)
 											break;
 										char rgb[12];
 										make_rgb(state.bc,rgb);
@@ -1168,17 +1151,15 @@ int main(int argc,char* args[])
 								printf("font-style:italic;");
 							if(state.blink)
 								printf("text-decoration:blink;");
-							if(state.fc_highlighted || state.bc_highlighted)
-								printf("filter: contrast(70%%) brightness(190%%);");
 
 							switch (state.fc_colormode)
 							{
-								case MODE_3BIT:
-									if (state.fc>=0 && state.fc<=9)
+								case MODE_4BIT:
+									if (state.fc>=0 && state.fc<=17)
 										printf("color:%s;", style.colors[state.fc]);
 									break;
 								case MODE_8BIT:
-									if (state.fc>=0 && state.fc<=7)
+									if (state.fc>=0 && state.fc<=15)
 										printf("color:%s;", style.colors[state.fc]);
 									else
 									{
@@ -1194,12 +1175,12 @@ int main(int argc,char* args[])
 
 							switch (state.bc_colormode)
 							{
-								case MODE_3BIT:
-									if (state.bc>=0 && state.bc<=9)
+								case MODE_4BIT:
+									if (state.bc>=0 && state.bc<=17)
 										printf("background-color:%s", style.colors[state.bc]);
 									break;
 								case MODE_8BIT:
-									if (state.bc>=0 && state.bc<=7)
+									if (state.bc>=0 && state.bc<=15)
 										printf("background-color:%s;", style.colors[state.bc]);
 									else
 									{

--- a/test_print.c
+++ b/test_print.c
@@ -3,12 +3,19 @@
 #define ANSI(str) "\x1b[" str
 
 #define ANSI_RESET ANSI("0m")
+
 #define ANSI_BOLD_ON ANSI("1m")
 #define ANSI_BOLD_OFF ANSI("22m")
+#define ANSI_FAINT_ON ANSI("2m")
+#define ANSI_FAINT_OFF ANSI("22m") // same as ANSI_BOLD_OFF
+#define ANSI_ITALIC_ON ANSI("3m")
+#define ANSI_ITALIC_OFF ANSI("23m")
 #define ANSI_UNDERSCORE_ON ANSI("4m")
 #define ANSI_UNDERSCORE_OFF ANSI("24m")
 #define ANSI_BLINK_ON ANSI("5m")
 #define ANSI_BLINK_OFF ANSI("25m")
+#define ANSI_INVERT_ON ANSI("7m")
+#define ANSI_INVERT_OFF ANSI("27m")
 #define ANSI_CROSSED_OUT_ON ANSI("9m")
 #define ANSI_CROSSED_OUT_OFF ANSI("29m")
 
@@ -64,18 +71,21 @@
 #define SEP_FG ANSI_FG_DEFAULT " "
 #define SEP_BG ANSI_BG_DEFAULT " "
 
-int main(int argc,char* args[])
-{
-	printf("===== ANSI debug =====\n");
-	printf("------- Styles -------\n");
+int main(int argc, char *args[]) {
+	printf(ANSI_BOLD_ON "===== ANSI debug =====\n" RST);
+	printf(ANSI_BOLD_ON "------- Styles -------\n" RST);
 	printf("Style: "
-		   ANSI_BOLD_ON "Bold" SEP
-		   ANSI_UNDERSCORE_ON "Underscore" SEP
-		   ANSI_BLINK_ON "Blink" SEP
-		   ANSI_CROSSED_OUT_ON "Crossed-out" NL);
+		   ANSI_BOLD_ON "Bold" ANSI_BOLD_OFF " "
+		   ANSI_ITALIC_ON "Italic" ANSI_ITALIC_OFF " "
+		   ANSI_UNDERSCORE_ON "Underscore" ANSI_UNDERSCORE_OFF " "
+		   ANSI_BLINK_ON "Blink" ANSI_BLINK_OFF " "
+		   ANSI_INVERT_ON "Invert" ANSI_INVERT_OFF " "
+		   ANSI_CROSSED_OUT_ON "Crossed-out" ANSI_CROSSED_OUT_OFF
+		   "\n");
 
-	printf("\n---- 3/4-bit color ---\n");
-	printf("FG Color (normal): "
+	printf(ANSI_BOLD_ON "\n---- 3/4-bit color ---\n" RST);
+
+	printf(ANSI_BOLD_ON "FG Color (normal): " RST
 		   ANSI_FG_BLACK "Black" SEP_FG
 		   ANSI_FG_RED "Red" SEP_FG
 		   ANSI_FG_GREEN "Green" SEP_FG
@@ -85,7 +95,7 @@ int main(int argc,char* args[])
 		   ANSI_FG_CYAN "Cyan" SEP_FG
 		   ANSI_FG_WHITE "White" SEP_FG
 		   ANSI_FG_DEFAULT "Default" NL);
-	printf("FG Color (bright): "
+	printf(ANSI_BOLD_ON "FG Color (bright): " RST
 		   ANSI_FG_LIGHT_BLACK "Black" SEP_FG
 		   ANSI_FG_LIGHT_RED "Red" SEP_FG
 		   ANSI_FG_LIGHT_GREEN "Green" SEP_FG
@@ -96,7 +106,7 @@ int main(int argc,char* args[])
 		   ANSI_FG_LIGHT_WHITE "White" SEP_FG
 		   ANSI_FG_DEFAULT "Default" NL);
 
-	printf("BG Color (normal): "
+	printf(ANSI_BOLD_ON "BG Color (normal): " RST
 		   ANSI_BG_BLACK "Black" SEP_BG
 		   ANSI_FG_BLACK // for contrast
 		   ANSI_BG_RED "Red" SEP_BG
@@ -107,7 +117,7 @@ int main(int argc,char* args[])
 		   ANSI_BG_CYAN "Cyan" SEP_BG
 		   ANSI_BG_WHITE "White"
 		   ANSI_BG_DEFAULT ANSI_FG_DEFAULT " Default" NL);
-	printf("BG Color (bright): "
+	printf(ANSI_BOLD_ON "BG Color (bright): " RST
 		   ANSI_BG_LIGHT_BLACK "Black" SEP_BG
 		   ANSI_FG_BLACK // for contrast
 		   ANSI_BG_LIGHT_RED "Red" SEP_BG
@@ -119,62 +129,62 @@ int main(int argc,char* args[])
 		   ANSI_BG_LIGHT_WHITE "White"
 		   ANSI_BG_DEFAULT ANSI_FG_DEFAULT " Default" NL);
 
-	printf("\n----- 8-bit color ----\n");
-	printf("FG Color (standard): ");
-	for(int i = 0; i < 8; i++) {
+	printf(ANSI_BOLD_ON "\n----- 8-bit color ----\n" RST);
+	printf(ANSI_BOLD_ON "FG Color (standard): " RST);
+	for (int i = 0; i < 8; i++) {
 		printf(ANSI_FG_8BIT("%d") "%d" SEP_FG, i, i);
 	}
 	printf("\n");
-	printf("FG Color (high-intensity): ");
-	for(int i = 8; i < 16; i++) {
+	printf(ANSI_BOLD_ON "FG Color (high-intensity): " RST);
+	for (int i = 8; i < 16; i++) {
 		printf(ANSI_FG_8BIT("%d") "%d" SEP_FG, i, i);
 	}
 	printf("\n");
-	printf("FG Color (216):");
-	for(int i = 16; i < 232; ) {
+	printf(ANSI_BOLD_ON "FG Color (216):" RST);
+	for (int i = 16; i < 232;) {
 		printf("\n    ");
-		for(int col = 0; col < 36; col++) {
+		for (int col = 0; col < 36; col++) {
 			printf(ANSI_FG_8BIT("%d") "%3d" SEP_FG, i, i);
 			i++;
 		}
 	}
 	printf("\n");
-	printf("FG Color (grayscale): ");
-	for(int i = 232; i < 256; i++) {
+	printf(ANSI_BOLD_ON "FG Color (grayscale): " RST);
+	for (int i = 232; i < 256; i++) {
 		printf(ANSI_FG_8BIT("%d") "%3d" SEP_FG, i, i);
 	}
 	printf("\n");
 
-	printf("BG Color (standard): ");
-	for(int i = 0; i < 8; i++) {
+	printf(ANSI_BOLD_ON "BG Color (standard): " RST);
+	for (int i = 0; i < 8; i++) {
 		printf(ANSI_BG_8BIT("%d") "%d" SEP_BG, i, i);
 	}
 	printf("\n");
-	printf("BG Color (high-intensity): ");
-	for(int i = 8; i < 16; i++) {
+	printf(ANSI_BOLD_ON "BG Color (high-intensity): " RST);
+	for (int i = 8; i < 16; i++) {
 		printf(ANSI_BG_8BIT("%d") "%d" SEP_BG, i, i);
 	}
 	printf("\n");
-	printf("BG Color (216):");
-	for(int i = 16; i < 232; ) {
+	printf(ANSI_BOLD_ON "BG Color (216):" RST);
+	for (int i = 16; i < 232;) {
 		printf("\n    ");
-		for(int col = 0; col < 36; col++) {
-			if(col >= 18)
+		for (int col = 0; col < 36; col++) {
+			if (col >= 18)
 				printf(ANSI_FG_8BIT("232")); // using ANSI_FG_BLACK is an edge case
 			printf(ANSI_BG_8BIT("%d") "%3d" SEP, i, i);
 			i++;
 		}
 	}
 	printf("\n");
-	printf("BG Color (grayscale): ");
-	for(int i = 232; i < 256; i++) {
-		if(i >= 244)
+	printf(ANSI_BOLD_ON "BG Color (grayscale): " RST);
+	for (int i = 232; i < 256; i++) {
+		if (i >= 244)
 			printf(ANSI_FG_8BIT("232")); // using ANSI_FG_BLACK is an edge case
 		printf(ANSI_BG_8BIT("%d") "%3d" SEP, i, i);
 	}
 	printf("\n");
 
-	printf("\n----- 24-bit color ----\n");
+	printf(ANSI_BOLD_ON "\n----- 24-bit color ----\n" RST);
 	char *rgb_colors[6] = {
 			"0;0;0",
 			"128;128;128",
@@ -184,32 +194,56 @@ int main(int argc,char* args[])
 			"0;0;255",
 	};
 
-	printf("FG Color (RGB): ");
-	for(int i = 0; i < 6; ) {
+	printf(ANSI_BOLD_ON "FG Color (RGB): " RST);
+	for (int i = 0; i < 6;) {
 		printf("\n    ");
-		for(int col = 0; col < 16 && i < 6; col++) {
+		for (int col = 0; col < 16 && i < 6; col++) {
 			printf(ANSI_FG_24BIT("%s") "%11s" SEP_FG, rgb_colors[i], rgb_colors[i]);
 			i++;
 		}
 	}
 	printf("\n");
 
-	printf("BG Color (RGB): ");
-	for(int i = 0; i < 6; ) {
+	printf(ANSI_BOLD_ON "BG Color (RGB): " RST);
+	for (int i = 0; i < 6;) {
 		printf("\n    ");
-		for(int col = 0; col < 16 && i < 6; col++) {
+		for (int col = 0; col < 16 && i < 6; col++) {
 			printf(ANSI_BG_24BIT("%s") "%11s" SEP_BG, rgb_colors[i], rgb_colors[i]);
 			i++;
 		}
 	}
 	printf("\n");
 
-	printf("\n------ Edge cases -----\n");
+	printf(ANSI_BOLD_ON "\n------- Special ------\n" RST);
+	printf(ANSI_BOLD_ON "Inverted (3-bit): " RST
+		   ANSI_FG_RED ANSI_BG_GREEN "Red on green "
+		   ANSI_INVERT_ON "Green on red" NL);
+	printf(ANSI_BOLD_ON "Inverted (8-bit): " RST
+		   ANSI_FG_8BIT("40") ANSI_BG_8BIT("170") "Green on pink"
+		   ANSI_INVERT_ON "Pink on green" NL);
+	printf(ANSI_BOLD_ON "Inverted (24-bit): " RST
+		   ANSI_FG_24BIT("160;32;240") ANSI_BG_24BIT("111;240;31") "Purple on green "
+		   ANSI_INVERT_ON "Green on purple" NL);
 
-	printf("8-bit foreground (blueish), 3-bit background (red):\n");
+	printf(ANSI_BOLD_ON "\n------ Edge cases -----\n" RST);
+
+	printf(ANSI_BOLD_ON "8-bit foreground (blueish), 3-bit background (red):\n" RST);
 	printf("    " ANSI_FG_8BIT("63") ANSI_BG_RED "Edge case" NL);
-	printf("when --stylesheet is enabled, the foreground will be put in a style attribute, and the 3-bit background "
-		   "class will end up in that style attribute and not the class attribute\n");
+	printf("    (when --stylesheet is enabled, the foreground will be put in a style attribute, and the 3-bit "
+		   "background class will end up in that style attribute and not the class attribute)\n");
+	printf(ANSI_BOLD_ON "Double-invert: " RST
+		   ANSI_FG_RED ANSI_BG_GREEN "Red on green "
+		   ANSI_INVERT_ON "Green on red "
+		   ANSI_INVERT_ON "Still green on red" NL);
+	printf(ANSI_BOLD_ON "Inverted (mixed 8/3-bit): " RST
+		   ANSI_FG_8BIT("92") ANSI_BG_GREEN "Purple on green "
+		   ANSI_INVERT_ON "Green on purple" NL);
+	printf(ANSI_BOLD_ON "Inverted (mixed 24/3-bit): " RST
+		   ANSI_FG_GREEN ANSI_BG_24BIT("160;32;240") "Green on purple"
+		   ANSI_INVERT_ON "Purple on green" NL);
+	printf(ANSI_BOLD_ON "Inverted (mixed 24/8-bit): " RST
+		   ANSI_FG_24BIT("160;32;240") ANSI_BG_8BIT("40") "Purple on green "
+		   ANSI_INVERT_ON "Green on purple" NL);
 
 	return 0;
 }

--- a/test_print.c
+++ b/test_print.c
@@ -1,0 +1,215 @@
+#include <stdio.h>
+
+#define ANSI(str) "\x1b[" str
+
+#define ANSI_RESET ANSI("0m")
+#define ANSI_BOLD_ON ANSI("1m")
+#define ANSI_BOLD_OFF ANSI("22m")
+#define ANSI_UNDERSCORE_ON ANSI("4m")
+#define ANSI_UNDERSCORE_OFF ANSI("24m")
+#define ANSI_BLINK_ON ANSI("5m")
+#define ANSI_BLINK_OFF ANSI("25m")
+#define ANSI_CROSSED_OUT_ON ANSI("9m")
+#define ANSI_CROSSED_OUT_OFF ANSI("29m")
+
+#define ANSI_FG_DEFAULT ANSI("39m")
+
+#define ANSI_FG_BLACK ANSI("30m")
+#define ANSI_FG_RED ANSI("31m")
+#define ANSI_FG_GREEN ANSI("32m")
+#define ANSI_FG_YELLOW ANSI("33m")
+#define ANSI_FG_BLUE ANSI("34m")
+#define ANSI_FG_MAGENTA ANSI("35m")
+#define ANSI_FG_CYAN ANSI("36m")
+#define ANSI_FG_WHITE ANSI("37m")
+
+#define ANSI_FG_LIGHT_BLACK ANSI("90m")
+#define ANSI_FG_LIGHT_RED ANSI("91m")
+#define ANSI_FG_LIGHT_GREEN ANSI("92m")
+#define ANSI_FG_LIGHT_YELLOW ANSI("93m")
+#define ANSI_FG_LIGHT_BLUE ANSI("94m")
+#define ANSI_FG_LIGHT_MAGENTA ANSI("95m")
+#define ANSI_FG_LIGHT_CYAN ANSI("96m")
+#define ANSI_FG_LIGHT_WHITE ANSI("97m")
+
+#define ANSI_FG_8BIT(color) ANSI("38;5;" color "m")
+#define ANSI_FG_24BIT(color) ANSI("38;2;" color "m")
+
+#define ANSI_BG_DEFAULT ANSI("49m")
+
+#define ANSI_BG_BLACK ANSI("40m")
+#define ANSI_BG_RED ANSI("41m")
+#define ANSI_BG_GREEN ANSI("42m")
+#define ANSI_BG_YELLOW ANSI("43m")
+#define ANSI_BG_BLUE ANSI("44m")
+#define ANSI_BG_MAGENTA ANSI("45m")
+#define ANSI_BG_CYAN ANSI("46m")
+#define ANSI_BG_WHITE ANSI("47m")
+
+#define ANSI_BG_LIGHT_BLACK ANSI("100m")
+#define ANSI_BG_LIGHT_RED ANSI("101m")
+#define ANSI_BG_LIGHT_GREEN ANSI("102m")
+#define ANSI_BG_LIGHT_YELLOW ANSI("103m")
+#define ANSI_BG_LIGHT_BLUE ANSI("104m")
+#define ANSI_BG_LIGHT_MAGENTA ANSI("105m")
+#define ANSI_BG_LIGHT_CYAN ANSI("106m")
+#define ANSI_BG_LIGHT_WHITE ANSI("107m")
+
+#define ANSI_BG_8BIT(color) ANSI("48;5;" color "m")
+#define ANSI_BG_24BIT(color) ANSI("48;2;" color "m")
+
+#define NL ANSI_RESET "\n"
+#define RST ANSI_RESET
+#define SEP RST " "
+#define SEP_FG ANSI_FG_DEFAULT " "
+#define SEP_BG ANSI_BG_DEFAULT " "
+
+int main(int argc,char* args[])
+{
+	printf("===== ANSI debug =====\n");
+	printf("------- Styles -------\n");
+	printf("Style: "
+		   ANSI_BOLD_ON "Bold" SEP
+		   ANSI_UNDERSCORE_ON "Underscore" SEP
+		   ANSI_BLINK_ON "Blink" SEP
+		   ANSI_CROSSED_OUT_ON "Crossed-out" NL);
+
+	printf("\n---- 3/4-bit color ---\n");
+	printf("FG Color (normal): "
+		   ANSI_FG_BLACK "Black" SEP_FG
+		   ANSI_FG_RED "Red" SEP_FG
+		   ANSI_FG_GREEN "Green" SEP_FG
+		   ANSI_FG_YELLOW "Yellow" SEP_FG
+		   ANSI_FG_BLUE "Blue" SEP_FG
+		   ANSI_FG_MAGENTA "Magenta" SEP_FG
+		   ANSI_FG_CYAN "Cyan" SEP_FG
+		   ANSI_FG_WHITE "White" SEP_FG
+		   ANSI_FG_DEFAULT "Default" NL);
+	printf("FG Color (bright): "
+		   ANSI_FG_LIGHT_BLACK "Black" SEP_FG
+		   ANSI_FG_LIGHT_RED "Red" SEP_FG
+		   ANSI_FG_LIGHT_GREEN "Green" SEP_FG
+		   ANSI_FG_LIGHT_YELLOW "Yellow" SEP_FG
+		   ANSI_FG_LIGHT_BLUE "Blue" SEP_FG
+		   ANSI_FG_LIGHT_MAGENTA "Magenta" SEP_FG
+		   ANSI_FG_LIGHT_CYAN "Cyan" SEP_FG
+		   ANSI_FG_LIGHT_WHITE "White" SEP_FG
+		   ANSI_FG_DEFAULT "Default" NL);
+
+	printf("BG Color (normal): "
+		   ANSI_BG_BLACK "Black" SEP_BG
+		   ANSI_FG_BLACK // for contrast
+		   ANSI_BG_RED "Red" SEP_BG
+		   ANSI_BG_GREEN "Green" SEP_BG
+		   ANSI_BG_YELLOW "Yellow" SEP_BG
+		   ANSI_BG_BLUE "Blue" SEP_BG
+		   ANSI_BG_MAGENTA "Magenta" SEP_BG
+		   ANSI_BG_CYAN "Cyan" SEP_BG
+		   ANSI_BG_WHITE "White"
+		   ANSI_BG_DEFAULT ANSI_FG_DEFAULT " Default" NL);
+	printf("BG Color (bright): "
+		   ANSI_BG_LIGHT_BLACK "Black" SEP_BG
+		   ANSI_FG_BLACK // for contrast
+		   ANSI_BG_LIGHT_RED "Red" SEP_BG
+		   ANSI_BG_LIGHT_GREEN "Green" SEP_BG
+		   ANSI_BG_LIGHT_YELLOW "Yellow" SEP_BG
+		   ANSI_BG_LIGHT_BLUE "Blue" SEP_BG
+		   ANSI_BG_LIGHT_MAGENTA "Magenta" SEP_BG
+		   ANSI_BG_LIGHT_CYAN "Cyan" SEP_BG
+		   ANSI_BG_LIGHT_WHITE "White"
+		   ANSI_BG_DEFAULT ANSI_FG_DEFAULT " Default" NL);
+
+	printf("\n----- 8-bit color ----\n");
+	printf("FG Color (standard): ");
+	for(int i = 0; i < 8; i++) {
+		printf(ANSI_FG_8BIT("%d") "%d" SEP_FG, i, i);
+	}
+	printf("\n");
+	printf("FG Color (high-intensity): ");
+	for(int i = 8; i < 16; i++) {
+		printf(ANSI_FG_8BIT("%d") "%d" SEP_FG, i, i);
+	}
+	printf("\n");
+	printf("FG Color (216):");
+	for(int i = 16; i < 232; ) {
+		printf("\n    ");
+		for(int col = 0; col < 36; col++) {
+			printf(ANSI_FG_8BIT("%d") "%3d" SEP_FG, i, i);
+			i++;
+		}
+	}
+	printf("\n");
+	printf("FG Color (grayscale): ");
+	for(int i = 232; i < 256; i++) {
+		printf(ANSI_FG_8BIT("%d") "%3d" SEP_FG, i, i);
+	}
+	printf("\n");
+
+	printf("BG Color (standard): ");
+	for(int i = 0; i < 8; i++) {
+		printf(ANSI_BG_8BIT("%d") "%d" SEP_BG, i, i);
+	}
+	printf("\n");
+	printf("BG Color (high-intensity): ");
+	for(int i = 8; i < 16; i++) {
+		printf(ANSI_BG_8BIT("%d") "%d" SEP_BG, i, i);
+	}
+	printf("\n");
+	printf("BG Color (216):");
+	for(int i = 16; i < 232; ) {
+		printf("\n    ");
+		for(int col = 0; col < 36; col++) {
+			if(col >= 18)
+				printf(ANSI_FG_8BIT("232")); // using ANSI_FG_BLACK is an edge case
+			printf(ANSI_BG_8BIT("%d") "%3d" SEP, i, i);
+			i++;
+		}
+	}
+	printf("\n");
+	printf("BG Color (grayscale): ");
+	for(int i = 232; i < 256; i++) {
+		if(i >= 244)
+			printf(ANSI_FG_8BIT("232")); // using ANSI_FG_BLACK is an edge case
+		printf(ANSI_BG_8BIT("%d") "%3d" SEP, i, i);
+	}
+	printf("\n");
+
+	printf("\n----- 24-bit color ----\n");
+	char *rgb_colors[6] = {
+			"0;0;0",
+			"128;128;128",
+			"255;255;255",
+			"255;0;0",
+			"0;255;0",
+			"0;0;255",
+	};
+
+	printf("FG Color (RGB): ");
+	for(int i = 0; i < 6; ) {
+		printf("\n    ");
+		for(int col = 0; col < 16 && i < 6; col++) {
+			printf(ANSI_FG_24BIT("%s") "%11s" SEP_FG, rgb_colors[i], rgb_colors[i]);
+			i++;
+		}
+	}
+	printf("\n");
+
+	printf("BG Color (RGB): ");
+	for(int i = 0; i < 6; ) {
+		printf("\n    ");
+		for(int col = 0; col < 16 && i < 6; col++) {
+			printf(ANSI_BG_24BIT("%s") "%11s" SEP_BG, rgb_colors[i], rgb_colors[i]);
+			i++;
+		}
+	}
+	printf("\n");
+
+	printf("\n------ Edge cases -----\n");
+
+	printf("8-bit foreground (blueish), 3-bit background (red):\n");
+	printf("    " ANSI_FG_8BIT("63") ANSI_BG_RED "Edge case" NL);
+	printf("when --stylesheet is enabled, the foreground will be put in a style attribute, and the 3-bit background "
+		   "class will end up in that style attribute and not the class attribute\n");
+
+	return 0;
+}


### PR DESCRIPTION
This PR makes a few improvements to Aha's color handling:

- It creates a test program `test_print.c` which outputs a page of formatting codes to test Aha with
![image](https://user-images.githubusercontent.com/5467669/101667378-2467e180-3a04-11eb-9630-8e8de239d23c.png)
- It replaces the old `highlighted` flag with proper 4-bit color support, including `.bg-highlighted` for independent foreground/background highlighting.
- Fixes a bug where a non-4-bit foreground color and a 4-bit background color would end up placing the 4-bit background class (e.g. `bg-red`) in the tag's `style` attribute instead of the `class` attribute
- It supplements the built-in color schemes with configurable ones using the `--colors` parameter

Because highlighting no longer uses a CSS filter and instead is a separate color, at the moment the built-in color schemes have no normal/bright distinction. I didn't want to go ahead and decide on a color scheme since, in the end, it's your project.