### PR TITLE
Adding brief details on 2 other ways to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,22 @@ Examples
 Compilation / Installation
 ==========================
 
+## Installation Options
+
+### OSX - Homebrew
+
+* `brew install aha`
+
+### Conda
+
+* `conda install -n YOURENV -c conda-forge aha` (and if you wish to make conda 10x faster, <a href=https://github.com/mamba-org/mamba >use mamba</a>).
+
+### Build From Source
+
 Aha has no dependencies except for a C compiler and `make`.
 
+Clone this repo `git clone https://github.com/theZiz/aha.git`.
+Move into the repo directory `cd aha`.
 To compile just type `make`.
 To install aha to `/usr/local/` type `make install`.
 You can change the installation directory with `make install PREFIX=/your/path`.


### PR DESCRIPTION
This package is exactly what I was looking for.  Thanks for creating it.  I found it via conda, so was suprised to see it was not mentioned as an install option (nor homebrew- i tested brew aha on Catalina, it worked, and I tested conda aha on Ubuntu 18 and 20 and it worked).  These routes will certainly make the tool more approachable.  Thanks again--